### PR TITLE
Jupiter clip fix

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,7 @@ function App() {
                 </section>
                 {/* about us */}
                 <section
-                    className="pt-16 p-10 bg-black/50 overflow-hidden"
+                    className="pt-16 p-10 bg-black/50 max-w-screen-2xl:overflow-hidden"
                     id="about"
                 >
                     <AboutUs />

--- a/src/Components/Hero.jsx
+++ b/src/Components/Hero.jsx
@@ -13,7 +13,10 @@ export default function Hero() {
                         HackHayward
                     </h1>
                     <p className="lg:text-4xl text-2xl mt-2 max-lg:text-center font-grotesk animate-fade-up shadow-text">
-                        Hosted by the:<br />Department of Computer Science @ CSUEB
+                        Hosted by:<br />
+                        <p className='lg:text-3xl text-xl font-thin'>
+                            Department of Computer Science @ CSUEB
+                        </p>
                     </p>
                     <p className="lg:text-4xl text-2xl max-lg:text-center font-grotesk animate-fade-up shadow-text">
                         Spring 2025


### PR DESCRIPTION
The Jupiter image tends to clip out of the overflow on extra-larger screens. This has been fixed with a max-width on such screens.