### PR TITLE
Updated registration form links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,7 +34,7 @@ function App() {
     // Notification Display
     const [display, setDisplay] = useState(false);
     // Links
-    const preRegister = "https://forms.fillout.com/t/cJH9deoDmCus";
+    const register = "https://forms.fillout.com/t/3wySorNxVMus";
 
     return (
         <>
@@ -44,7 +44,7 @@ function App() {
             </header>
             <main className="mainBackground bg-contain bg-repeat-y overflow-x-hidden">
                 <section className="border-b-8 border-[#c593e9]">
-                    <Hero preRegister={preRegister} />
+                    <Hero register={register} />
                 </section>
                 {/* about us */}
                 <section
@@ -55,7 +55,7 @@ function App() {
                 </section>
                 {/* FAQ */}
                 <section className="p-10 bg-black/50 overflow-hidden" id="faq">
-                    <FAQ preRegister={preRegister}/>
+                    <FAQ register={register}/>
                 </section>
                 {/* sponsor */}
                 <section
@@ -71,7 +71,7 @@ function App() {
             </main>
             {/* footer */}
             <footer className="bg-[rgb(48,37,45)] border-t-8 border-[#c593e9] overflow-hidden">
-                <Footer preRegister={preRegister} />
+                <Footer register={register} />
             </footer>
         </>
     );

--- a/src/Components/FAQ.jsx
+++ b/src/Components/FAQ.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 
 FaqAccordion.propTypes = {
-    preRegister: PropTypes.string.isRequired,
+    register: PropTypes.string.isRequired,
 };
 
 
@@ -33,14 +33,13 @@ function FaqAccordion(props) {
                 <>
                     Fill in{' '}
                     <a
-                        href={props.preRegister}
+                        href={props.register}
                         target="_blank"
                         className="text-[#c593e9] font-bold underline"
-                        onClick={() => handleClick('Pre-Register')}
+                        onClick={() => handleClick('Register')}
                     >
-                        our pre-registration form
-                    </a>{' '}
-                    and get informed when we open registration!
+                        our registration form!
+                    </a>
                 </>
             ),
         },
@@ -100,7 +99,7 @@ function FaqAccordion(props) {
 }
 
 FAQ.propTypes = {
-    preRegister: PropTypes.string.isRequired,
+    register: PropTypes.string.isRequired,
 };
 
 export default function FAQ(props) {
@@ -127,7 +126,7 @@ export default function FAQ(props) {
                         </a>
                     </p>
                 </div>
-                <FaqAccordion preRegister={props.preRegister} />
+                <FaqAccordion register={props.register} />
                 <div className="opacity-50 absolute top-0 right-[-10%] max-h-[40%] max-w-[40%] ">
                     <img src={saturn} loading="lazy" alt="Saturn" className="object-cover" />
                 </div>

--- a/src/Components/Footer.jsx
+++ b/src/Components/Footer.jsx
@@ -10,7 +10,7 @@ import {
 
 
 Footer.propTypes = {
-    preRegister: PropTypes.string.isRequired,
+    register: PropTypes.string.isRequired,
 };
 
 function SocialButtons() {
@@ -138,12 +138,12 @@ export default function Footer(props) {
                         <NavButtons />
                         <li className="px-2 max-[310px]:px-0 lg:hover:scale-110 transition">
                             <a
-                                href={props.preRegister}
+                                href={props.register}
                                 className="bg-[#c593e9] hover:bg-[#cfb0e8] rounded-full p-3 transition text-white lg:text-lg text-sm font-grotesk font-medium text-nowrap"
                                 target="_blank"
-                                onClick={() => handleClick('Pre-Register')}
+                                onClick={() => handleClick('Register')}
                             >
-                                Pre-Register
+                                Register
                             </a>
                         </li>
                     </ul>

--- a/src/Components/Hero.jsx
+++ b/src/Components/Hero.jsx
@@ -5,7 +5,8 @@ import astro from '/src/assets/imgs/hero/Astro.webp';
 import ReactGA from 'react-ga4';
 
 Hero.propTypes = {
-    preRegister: PropTypes.string.isRequired,
+    register: PropTypes.string.isRequired,
+    buttonText: "Register",
 };
 
 export default function Hero(props) {
@@ -41,10 +42,14 @@ export default function Hero(props) {
                             className="bg-[#c593e9] text-white lg:h-16 lg:px-14 h-12 px-6 pr-10
                         hover:bg-[#cfb0e8] transition max-lg:text-sm slash-r animate-flip-up text-center flex items-center"
                             target="_blank"
-                            href={props.preRegister}
-                            onClick={() => handleClick('Pre-Register')}
+                            href={props.register}
+                            onClick={() => handleClick('Register')}
                         >
-                            Pre-Register
+                            {/* Invisible span to reserve width */}
+                            <span className="absolute inset-0 flex items-center justify-center">Register</span>
+                            {/* Actual visible text */}
+                             <span className="invisible">Pre-Register</span>
+                            
                         </a>
                         <span className="slash-l-line animation-flip-down"></span>
                         <a


### PR DESCRIPTION
This pull request includes changes to update the registration link and related references across multiple components in the project. The main goal is to replace the pre-registration link with the new registration link.

Changes to registration link:
Updated the `preRegister` link to `register` and modified the references in `Hero`, `FAQ`, and `Footer` components accordingly.

Updates to component properties:

Changed the `preRegister` prop to `register` and updated the references in `FaqAccordion` and `FAQ` components. 
Updated the `preRegister` prop to `register` and modified the related references. 
Changed the `preRegister` prop to `register`, added a `buttonText` prop, and updated the related references. 