### PR TITLE
Fix blank page before loading screen on production

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,17 +47,61 @@
         <!-- Instant pre-loader shown before React mounts -->
         <div id="pre-loader" style="
             position: fixed; inset: 0; z-index: 99999;
-            display: flex; flex-direction: column; align-items: center; justify-content: center;
-            background: linear-gradient(135deg, #1A2773, #2a1a5e, #1A2773);
+            display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 24px;
+            background: linear-gradient(160deg, #1A2773 0%, #2a1a5e 40%, #46166C 70%, #1A2773 100%);
         ">
+            <!-- Spinner -->
             <div style="
-                width: 64px; height: 64px;
-                border: 3px solid rgba(183,148,212,0.2);
+                width: 48px; height: 48px;
+                border: 3px solid rgba(183,148,212,0.15);
                 border-top-color: #B794D4;
+                border-right-color: #c593e9;
                 border-radius: 50%;
-                animation: pre-spin 0.8s linear infinite;
+                animation: pre-spin 0.9s linear infinite;
             "></div>
-            <style>@keyframes pre-spin { to { transform: rotate(360deg); } }</style>
+            <!-- Title -->
+            <div style="
+                font-family: 'Exo 2', sans-serif;
+                font-size: 28px; font-weight: 700; letter-spacing: 1px;
+                background: linear-gradient(90deg, #B794D4, #c593e9, #B794D4);
+                -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+                background-clip: text;
+            ">HackHayward</div>
+            <!-- Subtitle -->
+            <div style="
+                font-family: 'Space Grotesk', sans-serif;
+                font-size: 11px; letter-spacing: 4px; text-transform: uppercase;
+                color: rgba(197,212,240,0.4);
+                margin-top: -16px;
+            ">Preparing for launch</div>
+            <!-- Stars -->
+            <div style="position:absolute;inset:0;overflow:hidden;pointer-events:none;" id="pre-stars"></div>
+            <style>
+                @keyframes pre-spin { to { transform: rotate(360deg); } }
+                @keyframes pre-twinkle {
+                    0%, 100% { opacity: 0.15; }
+                    50% { opacity: 0.9; }
+                }
+                .pre-star {
+                    position: absolute;
+                    background: white;
+                    border-radius: 50%;
+                    animation: pre-twinkle var(--d) ease-in-out infinite;
+                    animation-delay: var(--dl);
+                }
+            </style>
+            <script>
+                (function(){
+                    var c = document.getElementById('pre-stars');
+                    for(var i = 0; i < 50; i++){
+                        var s = document.createElement('div');
+                        s.className = 'pre-star';
+                        var size = (0.5 + Math.random() * 2.5) + 'px';
+                        s.style.cssText = 'left:' + (Math.random()*100) + '%;top:' + (Math.random()*100) + '%;width:' + size + ';height:' + size + ';--d:' + (2+Math.random()*4) + 's;--dl:' + (Math.random()*4) + 's;';
+                        c.appendChild(s);
+                    }
+                })();
+            </script>
         </div>
 
         <script type="module" src="/src/main.jsx"></script>

--- a/index.html
+++ b/index.html
@@ -35,16 +35,19 @@
         />
         <meta property="og:type" content="hackathon.event" />
 
-        
         <title>HackHayward</title>
+
+        <!-- Fonts: loaded via <link> instead of CSS @import for parallel loading -->
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Exo+2:ital,wght@0,100..900;1,100..900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&family=Space+Grotesk:wght@300..700&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap">
+
         <link rel="preload" href="/src/assets/imgs/hero/HeroScene-mobile.webp" as="image">
         <link rel="preload" href="/src/assets/imgs/hero/HeroScene.webp" as="image">
         <link rel="preload" href="/src/assets/imgs/hero/Astro.webp" as="image">
     </head>
     <body style="background:#1A2773; margin:0;">
-        <div id="root"></div>
-
-        <!-- Instant pre-loader shown before React mounts -->
+        <!-- Pre-loader BEFORE root so it paints first -->
         <div id="pre-loader" style="
             position: fixed; inset: 0; z-index: 99999;
             display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 24px;
@@ -59,9 +62,9 @@
                 border-radius: 50%;
                 animation: pre-spin 0.9s linear infinite;
             "></div>
-            <!-- Title -->
+            <!-- Title — uses system font so it's visible before web fonts load -->
             <div style="
-                font-family: 'Exo 2', sans-serif;
+                font-family: system-ui, -apple-system, sans-serif;
                 font-size: 28px; font-weight: 700; letter-spacing: 1px;
                 background: linear-gradient(90deg, #B794D4, #c593e9, #B794D4);
                 -webkit-background-clip: text; -webkit-text-fill-color: transparent;
@@ -69,7 +72,7 @@
             ">HackHayward</div>
             <!-- Subtitle -->
             <div style="
-                font-family: 'Space Grotesk', sans-serif;
+                font-family: system-ui, -apple-system, sans-serif;
                 font-size: 11px; letter-spacing: 4px; text-transform: uppercase;
                 color: rgba(197,212,240,0.4);
                 margin-top: -16px;
@@ -104,6 +107,7 @@
             </script>
         </div>
 
+        <div id="root"></div>
         <script type="module" src="/src/main.jsx"></script>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="background:#1A2773;">
     <head>
         <meta charset="UTF-8" />
         <link
@@ -41,7 +41,7 @@
         <link rel="preload" href="/src/assets/imgs/hero/HeroScene.webp" as="image">
         <link rel="preload" href="/src/assets/imgs/hero/Astro.webp" as="image">
     </head>
-    <body>
+    <body style="background:#1A2773; margin:0;">
         <div id="root"></div>
 
         <!-- Instant pre-loader shown before React mounts -->

--- a/src/Components/LoadingScreen.jsx
+++ b/src/Components/LoadingScreen.jsx
@@ -8,13 +8,12 @@ export default function LoadingScreen({ onFinished }) {
   const [progress, setProgress] = useState(0);
 
   const stars = useMemo(() =>
-    [...Array(50)].map(() => ({
+    [...Array(70)].map(() => ({
       left: `${Math.random() * 100}%`,
       top: `${Math.random() * 100}%`,
-      duration: 2 + Math.random() * 4,
-      delay: Math.random() * 4,
-      size: 0.5 + Math.random() * 2,
-      opacity: 0.3 + Math.random() * 0.7,
+      duration: 2 + Math.random() * 3,
+      delay: Math.random() * 3,
+      size: 1 + Math.random() * 2.5,
     })), []);
 
   const finish = useCallback(() => {
@@ -73,14 +72,32 @@ export default function LoadingScreen({ onFinished }) {
           transition={{ duration: 0.8, ease: 'easeInOut' }}
         >
           {/* Stars */}
+          <style>{`
+            .loader-star {
+              position: absolute;
+              background: white;
+              border-radius: 50%;
+              animation: loader-twinkle var(--d) ease-in-out infinite;
+              animation-delay: var(--dl);
+            }
+            @keyframes loader-twinkle {
+              0%, 100% { opacity: 0.2; }
+              50% { opacity: 1; }
+            }
+          `}</style>
           <div className="absolute inset-0 pointer-events-none">
             {stars.map((s, i) => (
-              <motion.div
+              <div
                 key={i}
-                className="absolute rounded-full bg-white"
-                style={{ left: s.left, top: s.top, width: s.size, height: s.size }}
-                animate={{ opacity: [s.opacity * 0.3, s.opacity, s.opacity * 0.3] }}
-                transition={{ duration: s.duration, repeat: Infinity, ease: 'easeInOut', delay: s.delay }}
+                className="loader-star"
+                style={{
+                  left: s.left,
+                  top: s.top,
+                  width: `${s.size}px`,
+                  height: `${s.size}px`,
+                  '--d': `${s.duration}s`,
+                  '--dl': `${s.delay}s`,
+                }}
               />
             ))}
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Exo+2:ital,wght@0,100..900;1,100..900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&family=Space+Grotesk:wght@300..700&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap');
+/* Fonts loaded via <link> in index.html for faster parallel loading */
 
 @tailwind base;
 @tailwind components;

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
             { "key": "Referrer-Policy", "value": "no-referrer" },
             {
                 "key": "Content-Security-Policy",
-                "value": "default-src 'self'; object-src 'none'; base-uri 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.google-analytics.com https://*.googletagmanager.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://*.google-analytics.com https://*.googletagmanager.com; connect-src 'self' blob: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com;"
+                "value": "default-src 'self'; object-src 'none'; base-uri 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://*.google-analytics.com https://*.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://*.google-analytics.com https://*.googletagmanager.com; connect-src 'self' blob: https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com;"
             },
             { "key": "X-XSS-Protection", "value": "1; mode=block" },
             { "key": "Permissions-Policy", "value": "geolocation=()" }


### PR DESCRIPTION
## Summary
- Fix Content-Security-Policy blocking all inline styles/scripts in the pre-loader
- Move Google Fonts from CSS `@import` to `<link>` tags for parallel loading
- Use system fonts in pre-loader for instant text visibility

## Root Cause
The CSP in `vercel.json` did not include `'unsafe-inline'` for `style-src` or `script-src`, which blocked every inline style and script in the HTML pre-loader — making it completely invisible on production.

## Changes
- `vercel.json` — Added `'unsafe-inline'` to `style-src` and `script-src`
- `index.html` — Pre-loader before `#root`, system fonts, font `<link>` tags with preconnect
- `src/index.css` — Removed `@import` (fonts now loaded via HTML `<link>`)

## Test plan
- [ ] Deploy to Vercel preview
- [ ] Hard refresh — pre-loader spinner + text should appear instantly (no blank page)
- [ ] Verify all fonts still load correctly across the site
- [ ] Verify loading screen spaceship animation still works